### PR TITLE
Trim whitespace from repo description text

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	_ "strconv"
 	"time"
+	"strings"
 )
 
 func main() {
@@ -95,6 +96,7 @@ func scrape(language string, filename string) {
 		title := s.Find("h3 a").Text()
 		owner := s.Find("span.prefix").Text()
 		description := s.Find("p.col-9").Text()
+		description = strings.TrimSpace(description)
 		url, _ := s.Find("h3 a").Attr("href")
 		url = "https://github.com" + url
 		ownerImg, _ := s.Find("p.repo-list-meta a img").Attr("src")


### PR DESCRIPTION
Repositories with emojis in the description add extra whitespace
which will render the description as a separate paragraph outside
of the list flow in the markdown html.