### PR TITLE
Insert whitespace between # and title

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -68,7 +68,7 @@ func createMarkDown(date string, filename string) {
 
 	// make a write buffer
 	w := bufio.NewWriter(fo)
-	w.WriteString("###" + date + "\n")
+	w.WriteString("### " + date + "\n")
 	w.Flush()
 }
 
@@ -84,7 +84,7 @@ func scrape(language string, filename string) {
 
 	defer f.Close()
 
-	if _, err = f.WriteString(fmt.Sprintf("\n####%s\n", language)); err != nil {
+	if _, err = f.WriteString(fmt.Sprintf("\n#### %s\n", language)); err != nil {
 		panic(err)
 	}
 


### PR DESCRIPTION
GitHub markdown requires whitespace between `#` and the title. This PR adds the whitespace in the script.