### PR TITLE
Simplify dateString() by using Time.Format

### DIFF
--- a/scraper.go
+++ b/scraper.go
@@ -40,17 +40,7 @@ func main() {
 }
 
 func dateString() string {
-	y, m, d := time.Now().Date()
-	mStr := fmt.Sprintf("%d", m)
-	dStr := fmt.Sprintf("%d", d)
-	if m < 10 {
-		mStr = fmt.Sprintf("0%d", m)
-	}
-	if d < 10 {
-		dStr = fmt.Sprintf("0%d", d)
-	}
-	return fmt.Sprintf("%d-%s-%s", y, mStr, dStr)
-
+	return fmt.Sprintf("%s", time.Now().Format("2006-01-02"))
 }
 
 func createMarkDown(date string, filename string) {


### PR DESCRIPTION
Golang has a convenient Time.Format function (https://golang.org/pkg/time/#Time.Format). As long as the reference time is specified properly in the provided format string, zero padding works as expected.

Test: https://play.golang.org/p/g54b95XO9xu